### PR TITLE
URL encode stuff

### DIFF
--- a/src/cd_client/core.clj
+++ b/src/cd_client/core.clj
@@ -2,7 +2,8 @@
   (:use [clojure.java.browse :only [browse-url]])
   (:require [cheshire.core :as json]
             [clj-http.client :as http]
-            [clojure.string :as string]))
+            [clojure.string :as string])
+  (:import java.net.URLEncoder))
 
 
 ;; For testing purposes use localhost:8080
@@ -114,8 +115,8 @@
 
 (defn search
   "Search for a method name within an (optional) namespace"
-  ([name]    (get-simple (str *search-api* name)))
-  ([ns name] (get-simple (str *search-api* ns "/" name))))
+  ([name]    (get-simple (str *search-api* (URLEncoder/encode (str name)))))
+  ([ns name] (get-simple (str *search-api* ns "/" (URLEncoder/encode (str name))))))
 
 
 (defn comments-core

--- a/src/cd_client/core.clj
+++ b/src/cd_client/core.clj
@@ -21,6 +21,7 @@
   that works on clojuredocs.org"
   [name]
   (-> name
+      URLEncoder/encode
       (string/replace "." "_dot")
       (string/replace "?" "_q")
       (string/replace "/" "_")))


### PR DESCRIPTION
Wasn't doing it before. Am doing it now.

Before:

``` clojure
user=> (examples ->>)
URISyntaxException Illegal character in path at index 53: http://api.clojuredocs.org:80/examples/clojure.core/->>  java.net.URI$Parser.fail (URI.java:2809)
```

After:

``` clojure
user=> (examples ->>)
{:url "http://clojuredocs.org/v/1660", :examples [{:namespace_id 99, :ns "clojure.core", :updated_at "2011-01-03 06:52:48.0", :function "->>", :version 6, :created_at "2010-07-23 23:14:24.0", :library "Clojure Core", :lib_version "1.2.0", :library_id 3, :body ";; get the sum of the first 10 even squares\nuser=> (->> (range)\n            (map #(* % %))\n            (filter even?)\n            (take 10)\n            (reduce +))\n1140\n\n;; this expands to:\nuser=> (reduce + (take 10 (filter even? (map #(* % %) (range)))))\n1140\n"}]}
```
